### PR TITLE
Port change, Dockerfile, deployment manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+fauxmetheus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.16.2-alpine as golang
+WORKDIR /fauxmetheus-build
+COPY . .
+RUN go build .
+
+FROM alpine
+COPY --from=golang /fauxmetheus-build/fauxmetheus /
+COPY --from=golang /fauxmetheus-build/tiny.json /
+COPY --from=golang /fauxmetheus-build/medium.json /
+ENTRYPOINT ["/fauxmetheus"]

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Serves fake Prometheus metrics which simulate a Linkerd cluster
 ```console
 > go build -o fauxmetheus *.go
 > ./fauxmetheus tiny.json
-Serving /metrics on :9990
+Serving /metrics on :4191
 ```
 
 ## Details
 
 Fauxmetheus reads its configuration from a json file (see `tiny.json` and
 `medium.json` for examples) and then serves a `/metrics` endpoint on port
-`9990`.  This endpoint returns Prometheus formatted metrics, simulating the
+`4191`.  This endpoint returns Prometheus formatted metrics, simulating the
 metrics that would be gathered from a cluster of Linkerd-proxy processes.
 The following metrics are included:
 

--- a/deployment.yml
+++ b/deployment.yml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: fauxmetheus
+    app.kubernetes.io/version: v0.9.0
+  name: fauxmetheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fauxmetheus
+  template:
+    metadata:
+      labels:
+        app: fauxmetheus
+    spec:
+      containers:
+      - args:
+        - medium.json
+        image: ghcr.io/alpeb/fauxmetheus:latest
+        imagePullPolicy: Always
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4191
+          name: linkerd-admin

--- a/main.go
+++ b/main.go
@@ -39,6 +39,6 @@ func main() {
 	counter = 0
 
 	http.Handle("/metrics", gziphandler.GzipHandler(http.HandlerFunc(handler)))
-	fmt.Println("Serving /metrics on :9990")
-	log.Fatal(http.ListenAndServe(":9990", nil))
+	fmt.Println("Serving /metrics on :4191")
+	log.Fatal(http.ListenAndServe(":4191", nil))
 }


### PR DESCRIPTION
- Changed port to standard 4191 metrics port
- Added Dockerfile to build image
- Added deployment manifest
- Added `.gitignore`