### PR TITLE
Run inside the 'fauxmetheus' namespace and create new profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,5 @@ RUN go build .
 
 FROM alpine
 COPY --from=golang /fauxmetheus-build/fauxmetheus /
-COPY --from=golang /fauxmetheus-build/tiny.json /
-COPY --from=golang /fauxmetheus-build/medium.json /
+COPY --from=golang /fauxmetheus-build/*.json /
 ENTRYPOINT ["/fauxmetheus"]

--- a/deployment.yml
+++ b/deployment.yml
@@ -1,3 +1,8 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: fauxmetheus
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,6 +10,7 @@ metadata:
     app.kubernetes.io/name: fauxmetheus
     app.kubernetes.io/version: v0.9.0
   name: fauxmetheus
+  namespace: fauxmetheus
 spec:
   replicas: 1
   selector:
@@ -17,7 +23,7 @@ spec:
     spec:
       containers:
       - args:
-        - medium.json
+        - small.json
         image: ghcr.io/alpeb/fauxmetheus:latest
         imagePullPolicy: Always
         name: linkerd-proxy

--- a/small.json
+++ b/small.json
@@ -1,0 +1,28 @@
+{
+    "deployments": [
+        {
+            "quantity": 1,
+            "pods": 10,
+            "fanIn": 1,
+            "fanOut": 100
+        },
+        {
+            "quantity": 2,
+            "pods": 10,
+            "fanIn": 30,
+            "fanOut": 30
+        },
+        {
+            "quantity": 2,
+            "pods": 10,
+            "fanIn": 10,
+            "fanOut": 10
+        },
+        {
+            "quantity": 2,
+            "pods": 10,
+            "fanIn": 30,
+            "fanOut": 0
+        }
+    ]
+}


### PR DESCRIPTION
`small.json` is the same as `medium.json` except that the last
deployment set has 2 deployments instead of 5, which outputs a number of
time series per metric right below 50k which is the limit we currently
have for Cortex in staging.